### PR TITLE
replace the incorrect house number that was incorrectly retained by OS

### DIFF
--- a/src/main/java/de/ukw/ccc/onkostar/hl7address/ReorgAddressPlugin.java
+++ b/src/main/java/de/ukw/ccc/onkostar/hl7address/ReorgAddressPlugin.java
@@ -104,21 +104,14 @@ public class ReorgAddressPlugin implements IProcedureAnalyzer {
         }
 
         var street = null == address.getStreet() ? "" : address.getStreet().trim();
-        var houseNumber = null == address.getHouseNumber() ? "" : address.getHouseNumber().trim();
 
-        // Case: StreetName contains HouseNumber
-        if (!houseNumber.isBlank() && (street.startsWith(houseNumber) || street.endsWith(houseNumber))) {
-            address.setStreet(Address.getStreetNameFromStreetAddress(street));
-            address.setHouseNumber(Address.getHouseNumberFromStreetAddress(street));
-        }
-        // Case empty HouseNumber - try to split
-        else if (houseNumber.isBlank()) {
-            address.setStreet(Address.getStreetNameFromStreetAddress(street));
-            address.setHouseNumber(Address.getHouseNumberFromStreetAddress(street));
-        } else {
-            // Exit in other cases
+        // Case: No HouseNumber within StreetAddress
+        if (Address.getHouseNumberFromStreetAddress(street).isBlank()) {
             return;
         }
+
+        address.setStreet(Address.getStreetNameFromStreetAddress(street));
+        address.setHouseNumber(Address.getHouseNumberFromStreetAddress(street));
 
         patient.setAddress(address);
         onkostarApi.savePatient(patient);

--- a/src/test/java/de/ukw/ccc/onkostar/hl7address/Hl7AddressPluginTest.java
+++ b/src/test/java/de/ukw/ccc/onkostar/hl7address/Hl7AddressPluginTest.java
@@ -74,7 +74,7 @@ public class Hl7AddressPluginTest {
     @Test
     void shouldSaveSplittedAddressWithExistingSplittedAddressIssue1() {
         // Mock existing patient
-        doAnswer(invocationOnMock -> dummyPatient(invocationOnMock.getArgument(0), "Am Breitenstein", "25")).when(onkostarApi).getPatient(anyString());
+        doAnswer(invocationOnMock -> dummyPatient(invocationOnMock.getArgument(0), "Am Schlag 4", "25")).when(onkostarApi).getPatient(anyString());
 
         // HL7 Message with new address: Am Schlag 4
         plugin.analyze(dummyHl7Message(2));


### PR DESCRIPTION
This will replace wrong house numbers retained by OS when importing HL7 messages without using this plugin.

OS replaces street including house number from HL7 message but keeps house number as it was.